### PR TITLE
multi: add github workflow to sync lnd and lit docs folders

### DIFF
--- a/.github/doc-sync.yaml
+++ b/.github/doc-sync.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
   # Run this workflow automatically once a day at midnight.
   # * is a special character in YAML so you have to quote this string
-  - cron: '*/0 0 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 defaults:

--- a/scripts/diff.sh
+++ b/scripts/diff.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ $# -ne 3 ];
+    then echo "args required: source repo, source dir, target dir"
+    exit 1
+fi
+
+# We will get our files from the source repo/dir.
+sourceDir="$1"/"$2"
+
+# We will copy these files to destination dir.
+destDir="$3"
+
+# Create our destination dir in case it does not yet exist, because we cannot
+# diff a directory that does not exist.
+mkdir -p "$destDir"
+
+# Copy everything from source to destination, replacing what's there.
+cp -rf "$sourceDir"/* "$destDir"
+
+# Remove the source repo that we cloned.
+rm -rf "$1"
+
+# If our sync has resulted in any changes, set an output for the rest of our
+# workflow.
+if [ -n "$(git status --porcelain)" ];
+  then echo ::set-output name=have_diff::"true"
+fi


### PR DESCRIPTION
This PR adds a github workflow that will sync documents from upstream repos. 
- `lnd/docs` -> `advanced-best-practices`
- `lightning-terminal/doc` -> `intermediate-get-lit`

The workflow will run automatically once a day at midnight, and can be manually triggered. 