### PR TITLE
multi: add github workflow to sync lnd and lit docs folders

### DIFF
--- a/.github/doc-sync.yaml
+++ b/.github/doc-sync.yaml
@@ -1,0 +1,69 @@
+name: Sync Documents
+
+on:
+  schedule:
+    # Run this workflow automatically once a day at midnight.
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  sync-docs:
+    name: Sync documents from upstream
+    runs-on: ubuntu-latest
+    strategy:
+      # Allow other tests in the matrix to continue if one fails.
+      fail-fast: false
+      matrix:
+        repo: [lnd, lightning-terminal]
+        include:
+          - repo: lnd
+            org: lightningnetwork
+            src: docs
+            dest: advanced-best-practices
+          - repo: lightning-terminal
+            org: lightninglabs
+            src: doc
+            dest: intermediate-get-lit
+
+    steps:
+      - name: Checkout docs.lightning.engineering repo
+        uses: actions/checkout@v2
+
+      - name: Checkout ${{ matrix.repo }} repo
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.org }}/${{ matrix.repo }}
+          path: ${{ matrix.repo }}
+
+      - name: Pull code differences
+        run: ./scripts/diff.sh ${{ matrix.repo }} ${{ matrix.src }} ${{ matrix.dest }}
+        id: create-diff
+
+      - name: Create Pull Request
+        if: steps.create-diff.outputs.have_diff == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: update documentation
+          title: Update ${{ matrix.repo }} documentation
+          body: This PR was created to automatically sync ${{ matrix.repo }} documentation.
+          branch: docs-${{ matrix.repo }}
+          base: master
+
+      - name: Check outputs
+        if: steps.create-diff.outputs.have_diff == 'true'
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+
+      - name: Merge Pull Request
+        if: steps.create-diff.outputs.have_diff == 'true'
+        uses: juliangruber/merge-pull-request-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/scripts/diff.sh
+++ b/scripts/diff.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ $# -ne 3 ];
+    then echo "args required: source repo, source dir, target dir"
+    exit 1
+fi
+
+# We will get our files from the source repo/dir.
+sourceDir="$1"/"$2"
+
+# We will copy these files to destination dir.
+destDir="$3"
+
+# Create our destination dir in case it does not yet exist, because we cannot
+# diff a directory that does not exist.
+mkdir -p "$destDir"
+
+# Copy everything from source to destination, replacing what's there.
+cp -rf "$sourceDir"/* "$destDir"
+
+# Remove the source repo that we cloned.
+rm -rf "$1"
+
+# If our sync has resulted in any changes, set an output for the rest of our
+# workflow.
+if [ -n "$(git status --porcelain)" ];
+  then echo ::set-output name=have_diff::"true"
+fi


### PR DESCRIPTION
This PR adds a doc sync workflow that will be triggered once a day, and can be run manually. 

It will sync the following directories:
- `lnd/docs` -> `advanced-best-practices`
- `litd/doc` -> `intermediate-get-lit`