### PR TITLE
workflow: sync all docs to single dir and add loop/pool/faraday

### DIFF
--- a/.github/workflows/doc-sync.yaml
+++ b/.github/workflows/doc-sync.yaml
@@ -24,11 +24,11 @@ jobs:
           - repo: lnd
             org: lightningnetwork
             src: docs
-            dest: advanced-best-practices
+            dest: docs/lnd
           - repo: lightning-terminal
             org: lightninglabs
             src: doc
-            dest: intermediate-get-lit
+            dest: docs/lit
 
     steps:
       - name: Checkout docs.lightning.engineering repo

--- a/.github/workflows/doc-sync.yaml
+++ b/.github/workflows/doc-sync.yaml
@@ -29,6 +29,18 @@ jobs:
             org: lightninglabs
             src: doc
             dest: docs/lit
+          - repo: loop 
+            org: lightninglabs
+            src: docs
+            dest: docs/loop
+          - repo: faraday 
+            org: lightninglabs
+            src: docs
+            dest: docs/faraday
+          - repo: pool 
+            org: lightninglabs
+            src: docs
+            dest: docs/pool
 
     steps:
       - name: Checkout docs.lightning.engineering repo


### PR DESCRIPTION
This commit updates our doc sync to pull all docs from other LL repos into `docs/{repo name}`. It also adds loop, pool and faraday docs, which were previously excluded because we didn't have place to put them. 

While testing this out locally, I noticed that the PR and merge GH action has a race when multiple PRs are made at the same time, and may fail because "master branch has changed". Since we run regular syncs, it's acceptable for the occasional failure (we can also always manually rerun if we need the sync immediately).