### PR TITLE
github: add codeowners for main directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Add codeowners for specific dirs in the repo based on who's written the 
+# majority of the content. The docs dir is intentionally excluded because we 
+# make automated PRs to it for the sync workflow.
+build-a-lapp/* @jamaljsr
+advanced-best-practices/* @carlaKC
+scripts/* @carlaKC
+community-resources/* @alexbosworth
+intermediate-get-lit/* @ryanthegentry
+


### PR DESCRIPTION
This PR adds codeowners for our main dirs. 

PRs that touch the dir you're assigned to will immediately assign you as a reviewer. This got quite noisy in the lnd repo, but I think is worth adding as we start out with docs at least so that we ensure contributor PRs get reviewed and people aren't discouraged because they fall through the cracks. 

Requesting review from everybody included, comment on the PR if you don't want to be included/ would like another allocation. 