### PR TITLE
workflows: set github user for actions commit

### DIFF
--- a/.github/workflows/doc-sync.yaml
+++ b/.github/workflows/doc-sync.yaml
@@ -65,6 +65,7 @@ jobs:
           title: Update ${{ matrix.repo }} documentation
           body: This PR was created to automatically sync ${{ matrix.repo }} documentation.
           branch: docs-${{ matrix.repo }}
+          author: GitHub <noreply@github.com>
           base: master
 
       - name: Check outputs


### PR DESCRIPTION
Use a generic github user for the author of our update commits.

The default for this action is to use the creator of the action, which makes it look like I'm padding my GH with a bot :')