### PR TITLE
workflows: run single doc-sync at a time

### DIFF
--- a/.github/workflows/doc-sync.yaml
+++ b/.github/workflows/doc-sync.yaml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       # Allow other tests in the matrix to continue if one fails.
       fail-fast: false
+      max-parallel: 1
       matrix:
         repo: [lnd, lightning-terminal]
         include:


### PR DESCRIPTION
If there are changes in multiple repos, the merge action can
fail because its view of master gets out of date.

Tested this out on my [fork](https://github.com/carlaKC/docs.lightning.engineering/actions/runs/689738184) - jobs ran in order and succeeded when 2x repos needed changes. 

Pull Request Checklist
- [ ] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
