### PR TITLE
workflows: add run-lnd readme to sync

### DIFF
--- a/.github/workflows/doc-sync.yaml
+++ b/.github/workflows/doc-sync.yaml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        repo: [lnd, lightning-terminal]
         include:
           - repo: lnd
             org: lightningnetwork
@@ -42,6 +41,10 @@ jobs:
             org: lightninglabs
             src: docs
             dest: docs/pool
+          - repo: run-lnd
+            org: alexbosworth
+            src: README.md
+            dest: docs/run-lnd
 
     steps:
       - name: Checkout docs.lightning.engineering repo

--- a/scripts/diff.sh
+++ b/scripts/diff.sh
@@ -16,7 +16,7 @@ destDir="$3"
 mkdir -p "$destDir"
 
 # Copy everything from source to destination, replacing what's there.
-cp -rf "$sourceDir"/* "$destDir"
+cp -a "$sourceDir" "$destDir"
 
 # Remove the source repo that we cloned.
 rm -rf "$1"


### PR DESCRIPTION
As requested by @ryanthegentry 🎉 

Tested this out on my fork because actions _never_ work on first run, demo [here](https://github.com/carlaKC/docs.lightning.engineering/actions/runs/842001266). Deleted my pool docs dir to make sure that the update to `diff.sh` works for directories and individual files. 

Pull Request Checklist
- [x] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
