### PR TITLE
Fixed typo

### DIFF
--- a/lightning-network-tools/lnd/payments.md
+++ b/lightning-network-tools/lnd/payments.md
@@ -145,7 +145,7 @@ Fee policies are structured with the following parameters:
 
 ### Invoice vs Keysend
 
-Payments can be made to an invoice supplied by the destination node, or using the experiential keysend feature, which is supported by all major implementations \(although un-upgraded nodes may not be able to receive these payments\). You may choose to support one or both of these sending methods, please consult the comparison table below to assess suitability for your use case:
+Payments can be made to an invoice supplied by the destination node, or using the experimental keysend feature, which is supported by all major implementations \(although un-upgraded nodes may not be able to receive these payments\). You may choose to support one or both of these sending methods, please consult the comparison table below to assess suitability for your use case:
 
 |  | Invoice | Keysend |
 | :--- | :--- | :--- |


### PR DESCRIPTION
I assume this line is trying to state that keysend is experimental

Pull Request Checklist
- [ ] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
