### PR TITLE
Make Markdown linguist-detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
Before this change, repository gets detected as:

Shell 100.0%

After this change, repository gets detected as:

Markdown 99.9%
Shell 0.1%

This change was added for a cosmetic effect on GitHub. It might be
good to go away once this repository is no longer hosted at GitHub, or
if GitHub ceases to use the line, or GitHub ceases to exist.

---

Pull Request Checklist
- [x] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
