### PR TITLE
migrating-lnd.md: serverl typo

### DIFF
--- a/lightning-network-tools/lnd/migrating-lnd.md
+++ b/lightning-network-tools/lnd/migrating-lnd.md
@@ -16,7 +16,7 @@ Do NOT run two LND instances with the same seed or public key.
 
 ## When to migrate LND
 
-There are lots of reasons why you might want to migrate your Lightning Node. You might be changing your host, move from a VPS to a personal physical serverl or just prefer to run LND in a different way. Migrating LND is a relatively straightforward and easy process that should not take long.
+There are lots of reasons why you might want to migrate your Lightning Node. You might be changing your host, move from a VPS to a personal physical server or just prefer to run LND in a different way. Migrating LND is a relatively straightforward and easy process that should not take long.
 
 If you have experienced a fatal error and would like to recover your Lightning node, do not use this guide. Regardless, it is good to read the article “[Planning for failure](recovery-planning-for-failure.md)” to learn how to best prepare for any recovery scenarios.
 


### PR DESCRIPTION
Pull Request Checklist
- [x] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.

More commits may be added here as I am reading through [`migrating-lnd`](https://docs.lightning.engineering/lightning-network-tools/lnd/migrating-lnd).