### PR TITLE
Update optimal-configuration-of-a-routing-node.md

### DIFF
--- a/lightning-network-tools/lnd/optimal-configuration-of-a-routing-node.md
+++ b/lightning-network-tools/lnd/optimal-configuration-of-a-routing-node.md
@@ -161,7 +161,7 @@ If a node returns many failures LND will begin to ignore them more and more. To 
 `routerrpc.attemptcost=10`\
 `routerrpc.attemptcostppm=10`
 
-LND may try less paths less likely to succeed only if they allow for significant savings. You can set the minimum of these desired savings here.
+LND may try paths less likely to succeed only if they allow for significant savings. You can set the minimum of these desired savings here.
 
 `routerrpc.maxmchistory=10000`
 


### PR DESCRIPTION
Fixed typo

Pull Request Checklist
- [x] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
