### PR TITLE
Update broken link

### DIFF
--- a/the-lightning-network/overview.md
+++ b/the-lightning-network/overview.md
@@ -26,8 +26,8 @@ The following guides assume basic knowledge of Bitcoin, specifically the UTXO mo
 [payment-channels](payment-channels/)
 {% endcontent-ref %}
 
-{% content-ref url="broken-reference" %}
-[Broken link](broken-reference)
+{% content-ref url="the-gossip-network/" %}
+[the-gossip-network](the-gossip-network/)
 {% endcontent-ref %}
 
 {% content-ref url="pathfinding/" %}


### PR DESCRIPTION
Fix the broken link.  It seems like it should link to `The Gossip Network` page.

Pull Request Checklist
- [x] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
