### PR TITLE
taro: remove incorrect --enable_emission flag

### DIFF
--- a/lightning-network-tools/taro/first-steps.md
+++ b/lightning-network-tools/taro/first-steps.md
@@ -10,7 +10,7 @@ description: >-
 
 Use `tarocli` to begin minting your first asset.
 
-`tarocli assets mint --type normal --name beefbux --supply 1000 –enable_emission false --meta "fantastic money"`
+`tarocli assets mint --type normal --name beefbux --supply 1000 --meta "fantastic money"`
 
 This will add your asset to a minting queue called a batch, which allows multiple assets to be created in a single minting transaction. This saves fees and conserves blockspace. Minting a transaction to the blockchain immediately is possible by appending the flag `--skip_batch` to the mint command.
 


### PR DESCRIPTION
This part has two errors in it:
 - There is only one dash
 - It's a boolean flag, so it cannot be set to false with the CLI library that we use (just omitting the flag will set the value to false)

Also, emission is currently not working.

Pull Request Checklist
- [ ] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
