### PR TITLE
Add LNURL Auth For WordPress

### DIFF
--- a/community-resources/resource-list.md
+++ b/community-resources/resource-list.md
@@ -72,6 +72,7 @@ description: >-
 * [Mash](https://getmash.com) - monetize your apps by integrating an open consumer lightning wallet, paywalls, and payment faciliation mechanisms with a few snippets of code
 * [sms4sats](https://sms4sats.com) - send text messages and receive sms for online services on the web and via API
 * [lightsats](https://lightsats.com) - Onboard newbies with lightning tips
+* [LNURL Auth For WordPress](https://wordpress.org/plugins/lnurl-auth/) - Login to WordPress with Bitcoin Lightning
 
 ## Software bundles that include Lightning <a href="#docs-internal-guid-083d9f26-7fff-e1ef-2503-fa578ae0e176" id="docs-internal-guid-083d9f26-7fff-e1ef-2503-fa578ae0e176"></a>
 


### PR DESCRIPTION
Add LNURL Auth For WordPress to Applications

Pull Request Checklist
- [ ] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
