### PR TITLE
fix typo in the command of `tapd`

### DIFF
--- a/lightning-network-tools/taproot-assets/get-tapd.md
+++ b/lightning-network-tools/taproot-assets/get-tapd.md
@@ -34,7 +34,7 @@ Within the `tap.conf` file you can permanently set your variables, such as direc
 
 Run Taproot Assets with the command `tapd`. Specify how Taproot Assets can reach LND and what bitcoin network to run Taproot Assets with by passing it additional flags.
 
-`tapd –network=testnet –debuglevel=debug —lnd.host=localhost:10009 --lnd.macaroonpath=/.lnd/data/chain/bitcoin/testnet/admin.macaroon --lnd.tlspath=/.lnd/tls.cert --tapdir=~/.taprooot-assets --rpclisten=127.0.0.1:10029 --restlisten=127.0.0.1:8089`
+`tapd --network=testnet –debuglevel=debug --lnd.host=localhost:10009 --lnd.macaroonpath=/.lnd/data/chain/bitcoin/testnet/admin.macaroon --lnd.tlspath=/.lnd/tls.cert --tapdir=~/.taprooot-assets --rpclisten=127.0.0.1:10029 --restlisten=127.0.0.1:8089`
 
 You may run multiple tapd instances on the same machine, but you will also have to set up multiple LND instances. [Refer to this guide](../lnd/run-lnd.md) for how to set up multiple LND instances with a single Bitcoin backend using `rpcpolling`. When running multiple `tapd` instances on one machine, don’t forget to set an alternate Taproot Assets directory and API endpoints and specify these when calling `tapcli` as well.
 


### PR DESCRIPTION
Pull Request Checklist
- [x] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
