### PR TITLE
HTLC: add more explanation

### DIFF
--- a/the-lightning-network/multihop-payments/hash-time-lock-contract-htlc.md
+++ b/the-lightning-network/multihop-payments/hash-time-lock-contract-htlc.md
@@ -37,7 +37,9 @@ ELSE CHECKLOCKTIME
     <sender pubkey>
 ```
 
-Depending on the route chosen, Bob might now forward this HTLC by creating a new commitment transaction for one of his channels, removing 1 BTC from his channel balance. Then, he commits it into a HTLC with the same preimage hash with a swapped recover pubkey of his channel peer and his sender pubkey.
+The `revocation pubkey` is to prevent either Bob or Alice from stealing funds by publishing older channel state. The `recover pubkey` is Bob's key to claim the 1 BTC if he provides the `preimage` from the final receiver (meaning the transaction went through). The `sender pubkey` is Alice's key to claim the 1BTC back after certain time, if Bob doesn't show the `preimage`.
+
+Depending on the route chosen, Bob might now forward this HTLC by creating a new commitment transaction for one of his channels, removing 1 BTC from his channel balance. Then, he commits it into a similar HTLC with the same preimage hash with a swapped recover pubkey of his channel peer (so that the peer can claim the 1 BTC if they get the preimage) and his sender pubkey (so that Bob can claim the 1 BTC after certain time).
 
 ## 3) A HTLC is consolidated
 


### PR DESCRIPTION
I was reading https://docs.lightning.engineering/the-lightning-network/multihop-payments/hash-time-lock-contract-htlc and it took me a while to understand. I think adding a bit more explanation might help other people.

If someone could double check that the text is actually correct, that would be great, because I'm not 100% confident.

Also, I'm not sure if this is the right repo to change it (I can see that some docs are automatically pulled from lnd repo), so please let me know if I should change it somewhere else.

Happy to discard this if people don't think this is helpful to understand.

Pull Request Checklist
- [ ] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
