### PR TITLE
Add github action to find HTTP resources returning a 404 error code

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,17 @@
+name: Markdown lint
+# https://github.com/marketplace/actions/404-links
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: 'restqa-404-links'
+      uses: restqa/404-links@3.1.4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/lnd/INSTALL.md
+++ b/docs/lnd/INSTALL.md
@@ -100,16 +100,16 @@ the following commands for your OS:
   <summary>Linux (x86-64)</summary>
   
   ```
-  wget https://dl.google.com/go/go1.19.7.linux-amd64.tar.gz
-  sha256sum go1.19.7.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
+  wget https://dl.google.com/go/go1.22.4.linux-amd64.tar.gz
+  sha256sum go1.22.4.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
   ```
 
   The final output of the command above should be
-  `7a75720c9b066ae1750f6bcc7052aba70fa3813f4223199ee2a2315fd3eb533d`. If it
+  `ba79d4526102575196273416239cca418a651e049c2b099f3159db85e7bade7d`. If it
   isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo tar -C /usr/local -xzf go1.19.7.linux-amd64.tar.gz
+  sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.22.4.linux-amd64.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```
 </details>
@@ -118,16 +118,16 @@ the following commands for your OS:
   <summary>Linux (ARMv6)</summary>
   
   ```
-  wget https://dl.google.com/go/go1.19.7.linux-armv6l.tar.gz
-  sha256sum go1.19.7.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
+  wget https://dl.google.com/go/go1.22.4.linux-armv6l.tar.gz
+  sha256sum go1.22.4.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
   ```
 
   The final output of the command above should be
-  `93b1f621ddfc2c2b4e383e185fa7801e80f8b546918cb96afea2723677928312`. If it
+  `e2b143fbacbc9cbd448e9ef41ac3981f0488ce849af1cf37e2341d09670661de`. If it
   isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  tar -C /usr/local -xzf go1.19.7.linux-armv6l.tar.gz
+  sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.4.linux-armv6l.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```  
   

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -209,6 +209,17 @@
   its bitcoin peers' `feefilter` values into
   account](https://github.com/lightningnetwork/lnd/pull/8418).
 
+* Web fee estimator settings have been moved into a new `fee` config group.
+  A new `fee.url` option has been added within this group that replaces the old
+  `feeurl` option, which is now deprecated. Additionally, [two new config values,
+  fee.min-update-timeout and fee.max-update-timeout](https://github.com/lightningnetwork/lnd/pull/8484)
+  are added to allow users to specify the minimum and maximum time between fee
+  updates from the web fee estimator. The default values are 5 minutes and 20
+  minutes respectively. These values are used to prevent the fee estimator from
+  being queried too frequently. This replaces previously hardcoded values that
+  were set to the same values as the new defaults. The previously deprecated
+  `neutrino.feeurl` option has been removed.
+
 * [Preparatory work](https://github.com/lightningnetwork/lnd/pull/8159) for 
   forwarding of blinded routes was added, along with [support](https://github.com/lightningnetwork/lnd/pull/8160)
   for forwarding blinded payments and [error handling](https://github.com/lightningnetwork/lnd/pull/8485).
@@ -433,6 +444,9 @@
   logged](https://github.com/lightningnetwork/lnd/pull/8693) when no values are
   specified.
 
+* Removed deprecated `neutrino.feeurl` option. Please use the newer `fee.url`
+  option instead.
+
 ## Performance Improvements
 
 * Watchtower client DB migration to massively [improve the start-up 
@@ -569,6 +583,7 @@
 * testwill
 * Thabokani
 * threewebcode
+* Tom Kirkpatrick
 * Turtle
 * twofaktor
 * vuittont60

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -204,7 +204,9 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   by default, and the feature is not yet advertised to the network.
 
 * Introduced [fee bumper](https://github.com/lightningnetwork/lnd/pull/8424) to
-  handle bumping the fees of sweeping transactions properly.
+  handle bumping the fees of sweeping transactions properly. A
+  [README.md](https://github.com/lightningnetwork/lnd/pull/8674) is added to
+  explain this new approach.
 
 ## RPC Additions
 

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -187,7 +187,9 @@ call where arguments were swapped.
 bitcoin peers' feefilter values into account](https://github.com/lightningnetwork/lnd/pull/8418).
 
 * [Preparatory work](https://github.com/lightningnetwork/lnd/pull/8159) for 
-  forwarding of blinded routes was added.
+  forwarding of blinded routes was added, along with [support](https://github.com/lightningnetwork/lnd/pull/8160)
+  for forwarding blinded payments. Forwarding of blinded payments is disabled 
+  by default, and the feature is not yet advertised to the network.
 
 ## RPC Additions
 

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -118,6 +118,14 @@
 
 * [Fixed a bug in `btcd` that caused an incompatibility with
   `bitcoind v27.0`](https://github.com/lightningnetwork/lnd/pull/8573).
+  
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8609) a function call 
+  where arguments were swapped.
+
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8545) utxo selection
+  for the internal channel funding flow (Single and Batch Funding Flow). Now
+  utxos which are unconfirmed and originated from the sweeper subsystem are not
+  selected because they bear the risk of being replaced (BIP 125 RBF).
 
 # New Features
 ## Functional Enhancements

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -317,6 +317,10 @@
 * [Add inbound fees](https://github.com/lightningnetwork/lnd/pull/8723) to 
   `subscribeChannelGraph`.
 
+* [Moved](https://github.com/lightningnetwork/lnd/pull/8744) the experimental
+  "custom" options to the main protocol config so that they can be used without
+  the dev build flag set.
+
 ### Logging
 * [Add the htlc amount](https://github.com/lightningnetwork/lnd/pull/8156) to
   contract court logs in case of timed-out HTLCs in order to easily spot dust

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -172,6 +172,9 @@
 * When computing a minimum fee for transaction construction, `lnd` [now takes our
 bitcoin peers' feefilter values into account](https://github.com/lightningnetwork/lnd/pull/8418).
 
+* [Preparatory work](https://github.com/lightningnetwork/lnd/pull/8159) for 
+  forwarding of blinded routes was added.
+
 ## RPC Additions
 
 * [Deprecated](https://github.com/lightningnetwork/lnd/pull/7175)

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -107,7 +107,8 @@
   which with the default fee allocation in place will eventually lead to the
   downsizing to the fee floor (1 sat/vByte) in the worst case.
 
-* [Removed](https://github.com/lightningnetwork/lnd/pull/8577) some unreachable code
+* [Removed](https://github.com/lightningnetwork/lnd/pull/8577) some unreachable
+  code.
 
 * [Fixed](https://github.com/lightningnetwork/lnd/pull/8609) a function
   call where arguments were swapped.
@@ -118,20 +119,14 @@
 
 * [Fixed a bug in `btcd` that caused an incompatibility with
   `bitcoind v27.0`](https://github.com/lightningnetwork/lnd/pull/8573).
-  
-* [Fixed](https://github.com/lightningnetwork/lnd/pull/8609) a function call 
-  where arguments were swapped.
 
-* [Fixed](https://github.com/lightningnetwork/lnd/pull/8545) utxo selection
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8545) UTXO selection
   for the internal channel funding flow (Single and Batch Funding Flow). Now
-  utxos which are unconfirmed and originated from the sweeper subsystem are not
+  UTXOs which are unconfirmed and originated from the sweeper subsystem are not
   selected because they bear the risk of being replaced (BIP 125 RBF).
-
-* [Fixed](https://github.com/lightningnetwork/lnd/pull/8685) lncli "bumpfee"
-  parsing of the immediate/force flag.
   
 * [Fixed](https://github.com/lightningnetwork/lnd/pull/8621) the behaviour of
-  neutrino LND nodes which would loose sync in case they had very unstable
+  neutrino LND nodes which would lose sync in case they had very unstable
   peer connection.
 
 # New Features
@@ -151,13 +146,13 @@
   can be enabled with the option `accept-positive-inbound-fees`.
 
 * A new config value,
-  [sweeper.maxfeerate](https://github.com/lightningnetwork/lnd/pull/7823), is
+  [`sweeper.maxfeerate`](https://github.com/lightningnetwork/lnd/pull/7823), is
   added so users can specify the max allowed fee rate when sweeping on-chain
-  funds. The default value is 1000 sat/vb. Setting this value below 100 sat/vb
+  funds. The default value is 1000 sat/vB. Setting this value below 100 sat/vB
   is not allowed, as low fee rate can cause transactions not confirming in
   time, which could result in fund loss.
   Please note that the actual fee rate to be used is determined by the fee
-  estimator used(for instance `bitcoind`), and this value is a cap on the max
+  estimator used (for instance `bitcoind`), and this value is a cap on the max
   allowed value. So it's expected that this cap is rarely hit unless there's
   mempool congestion.
 
@@ -210,8 +205,9 @@
   `lnd.conf`](https://github.com/lightningnetwork/lnd/pull/8310)
   for the `rpcuser` and `rpcpass` fields to better protect the secrets.
 
-* When computing a minimum fee for transaction construction, `lnd` [now takes our
-bitcoin peers' feefilter values into account](https://github.com/lightningnetwork/lnd/pull/8418).
+* When computing a minimum fee for transaction construction, `lnd` [now takes
+  its bitcoin peers' `feefilter` values into
+  account](https://github.com/lightningnetwork/lnd/pull/8418).
 
 * [Preparatory work](https://github.com/lightningnetwork/lnd/pull/8159) for 
   forwarding of blinded routes was added, along with [support](https://github.com/lightningnetwork/lnd/pull/8160)
@@ -268,7 +264,7 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 
 * Deprecate `bumpclosefee` for `bumpforceclosefee` to accommodate for the fact 
   that only force closing transactions can be bumped to avoid confusion. 
-  Moreover allow to specify a max fee rate range when coop closing a channel.
+  Moreover, allow to specify a max fee rate range when coop closing a channel.
   [Deprecate bumpclosefee for bumpforceclosefee and add `max_fee_rate` option
    to `closechannel` cmd](https://github.com/lightningnetwork/lnd/pull/8350).
 
@@ -347,7 +343,8 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 
 * [Coin Selection Strategy](https://github.com/lightningnetwork/lnd/pull/8515)
   add coin selection strategy option to the following on-chain RPC calls
-  `EstimateFee`, `SendMany`, `SendCoins`, `BatchOpenChannel`, `SendOutputs`, and `FundPsbt`.
+  `EstimateFee`, `SendMany`, `SendCoins`, `BatchOpenChannel`, `SendOutputs`, and
+  `FundPsbt`.
 
 * `BumpFee` has been updated to take advantage of the [new budget-based
   sweeper](https://github.com/lightningnetwork/lnd/pull/8667). The param
@@ -365,7 +362,7 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 
 * When paying an AMP payment request, [the `--amp` flag is now
   required](https://github.com/lightningnetwork/lnd/pull/8681) to be consistent
-  w/ the flow when a payment request isn't used. 
+  with the flow when a payment request isn't used. 
 
 ## lncli Updates
 
@@ -425,7 +422,7 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 
 ## Breaking Changes
 
-* Previously when callng `SendCoins`, `SendMany`, `OpenChannel` and
+* Previously when calling `SendCoins`, `SendMany`, `OpenChannel` and
   `CloseChannel` for coop close, it is allowed to specify both an empty
   `SatPerVbyte` and `TargetConf`, and a default conf target of 6 will be used.
   This will [no longer be
@@ -517,7 +514,7 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   settings between `sqldb` and `kvdb` packages.
 
 * [Expanded SweeperStore](https://github.com/lightningnetwork/lnd/pull/8147) to
-  also store the feerate, fees paid, and whether it's published or not for a
+  also store the fee rate, fees paid, and whether it's published or not for a
   given sweeping transaction.
 
 ## Code Health
@@ -525,30 +522,59 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 * [Remove database pointers](https://github.com/lightningnetwork/lnd/pull/8117) 
   from `channeldb` schema structs.
 
-## Tooling and Documentation
-
 # Contributors (Alphabetical Order)
 
 * Alex Akselrod
+* Alex Sears
 * Amin Bashiri
 * Andras Banki-Horvath
+* AtomicInnovation321
+* bartoli
 * BitcoinerCoderBob
+* bitromortac
+* bota87
+* Calvin Zachman
 * Carla Kirk-Cohen
+* cristiantroy
+* cuinix
+* davisv7
 * Elle Mouton
 * ErikEk
+* Eugene Siegel
 * Feelancer21
+* ffranr
+* Hao Wang
+* hidewrong
 * Jesse de Wit
+* João Thallis
+* Jonathan Harvey-Buschel
 * Joost Jager
+* Jordi Montes
 * Keagan McClelland
+* kilrau
+* mani2310
 * Marcos Fernandez Perez
 * Matt Morehouse
+* Michael Rooke
 * Mohamed Awnallah
 * Olaoluwa Osuntokun
+* Oliver Gugger
 * Ononiwu Maureen Chiamaka
+* Sam Korn
+* saubyk
+* Simone Ragonesi
 * Slyghtning
+* tdb3
 * Tee8z
+* testwill
+* Thabokani
+* threewebcode
 * Turtle
-* Hao Wang
+* twofaktor
+* vuittont60
 * w3irdrobot
+* weiliy
+* xiaoxianBoy
 * Yong Yu
+* zhiqiangxu
 * Ziggie

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -109,8 +109,12 @@
 
 * [Removed](https://github.com/lightningnetwork/lnd/pull/8577) some unreachable code
 
-[Fixed](https://github.com/lightningnetwork/lnd/pull/8609) fixed a function
-call where arguments were swapped.
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8609) a function
+  call where arguments were swapped.
+
+* [Addresses derived from imported watch-only accounts now correctly include
+  their master key's
+  fingerprint](https://github.com/lightningnetwork/lnd/pull/8630).
 
 # New Features
 ## Functional Enhancements

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -284,7 +284,9 @@
 
 * [Man pages](https://github.com/lightningnetwork/lnd/pull/8525) Generate man
   pages automatically using `lncli generatemanpage` command for both `lncli`
-  and `lnd` commands when running `make install` in the Makefile.
+  and `lnd` commands when running 
+  [`make install-all`](https://github.com/lightningnetwork/lnd/pull/8739) in 
+  the Makefile.
 
 # Improvements
 ## Functional Updates

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -392,6 +392,11 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   and makes TLV Onions, Static Remote Keys, Gossip Queries, compulsory features
   for LND's peers. Data Loss Protection has been compulsory for years.
 
+* [Don't Require Gossip Queries](https://github.com/lightningnetwork/lnd/pull/8615)
+  This change undoes a portion of what was introduced in #8275 due to a subsequent
+  [spec change](https://github.com/lightning/bolts/pull/1092/commits/e0ee59f3c92b7c98be8dfc47b7db358b45baf9de)
+  that meant we shouldn't require it.
+
 ## Testing
 
 * Added fuzz tests for [onion

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -134,7 +134,7 @@ call where arguments were swapped.
   allowed value. So it's expected that this cap is rarely hit unless there's
   mempool congestion.
 
-* Support for [pathfinding]((https://github.com/lightningnetwork/lnd/pull/7267)
+* Support for [pathfinding](https://github.com/lightningnetwork/lnd/pull/7267)
   and payment to blinded paths has been added via the `QueryRoutes` (and 
   `SendToRouteV2`) APIs. This functionality is surfaced in `lncli queryroutes` 
   where the required flags are tagged with `(blinded paths)`. Updates to mission

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -116,6 +116,9 @@
   their master key's
   fingerprint](https://github.com/lightningnetwork/lnd/pull/8630).
 
+* [Fixed a bug in `btcd` that caused an incompatibility with
+  `bitcoind v27.0`](https://github.com/lightningnetwork/lnd/pull/8573).
+
 # New Features
 ## Functional Enhancements
 

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -440,6 +440,10 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 * [Turn `sqldb` into a separate Go
   module](https://github.com/lightningnetwork/lnd/pull/8603).
 
+* [Consolidate transaction 
+  retry](https://github.com/lightningnetwork/lnd/pull/8611) logic and isolation
+  settings between `sqldb` and `kvdb` packages.
+
 ## Code Health
 
 * [Remove database pointers](https://github.com/lightningnetwork/lnd/pull/8117) 

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -314,6 +314,9 @@
   maintain a healthy connection to the network by checking the number of
   outbound peers if they are below 6.
 
+* [Add inbound fees](https://github.com/lightningnetwork/lnd/pull/8723) to 
+  `subscribeChannelGraph`.
+
 ### Logging
 * [Add the htlc amount](https://github.com/lightningnetwork/lnd/pull/8156) to
   contract court logs in case of timed-out HTLCs in order to easily spot dust
@@ -549,6 +552,7 @@
 * BitcoinerCoderBob
 * bitromortac
 * bota87
+* Bufo
 * Calvin Zachman
 * Carla Kirk-Cohen
 * cristiantroy

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -127,6 +127,13 @@
   utxos which are unconfirmed and originated from the sweeper subsystem are not
   selected because they bear the risk of being replaced (BIP 125 RBF).
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8685) lncli "bumpfee"
+  parsing of the immediate/force flag.
+  
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8621) the behaviour of
+  neutrino LND nodes which would loose sync in case they had very unstable
+  peer connection.
+
 # New Features
 ## Functional Enhancements
 
@@ -355,6 +362,12 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   `budget`, and `deadline_height`, the fields `force`, `requested_conf_target`,
   and `next_broadcast_height` are deprecated.
 
+* [Delete All Payments RPC](https://github.com/lightningnetwork/lnd/pull/8672)
+  adds `all_payments` option to the `DeleteAllPayments` RPC. This update
+  ensures that the arguments are provided when calling `DeleteAllPayments` RPC,
+  whether through gRPC or the REST API, due to the destructive nature of the
+  operation.
+
 ## lncli Updates
 
 * [Documented all available `lncli`
@@ -389,7 +402,10 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   In particular, the complexity involved in the lifecycle loop has been
   decoupled into logical steps, with each step having its own responsibility,
   making it easier to reason about the payment flow.
- 
+
+* [Remove io/ioutil package 
+  dependence](https://github.com/lightningnetwork/lnd/pull/7765).
+
 * [Add a watchtower tower client
   multiplexer](https://github.com/lightningnetwork/lnd/pull/7702) to manage
   tower clients of different types.

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -265,6 +265,11 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   types](https://github.com/lightningnetwork/lnd/pull/8554) defined in
   `btcd/rpcclient`.
 
+* [checkOutboundPeers](https://github.com/lightningnetwork/lnd/pull/8576) is
+  added to `chainHealthCheck` to make sure chain backend `bitcoind` and `btcd`
+  maintain a healthy connection to the network by checking the number of
+  outbound peers if they are below 6.
+
 ### Logging
 * [Add the htlc amount](https://github.com/lightningnetwork/lnd/pull/8156) to
   contract court logs in case of timed-out HTLCs in order to easily spot dust
@@ -431,6 +436,9 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 
 * [Fix a bug](https://github.com/lightningnetwork/lnd/pull/8595) when retrying
   SQL InvoiceDB transactions due to database errors.
+
+* [Turn `sqldb` into a separate Go
+  module](https://github.com/lightningnetwork/lnd/pull/8603).
 
 ## Code Health
 

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -1,4 +1,5 @@
 # Release Notes
+- [Release Notes](#release-notes)
 - [Bug Fixes](#bug-fixes)
 - [New Features](#new-features)
   - [Functional Enhancements](#functional-enhancements)
@@ -6,12 +7,14 @@
   - [lncli Additions](#lncli-additions)
 - [Improvements](#improvements)
   - [Functional Updates](#functional-updates)
+    - [Tlv](#tlv)
+  - [Misc](#misc)
+    - [Logging](#logging)
   - [RPC Updates](#rpc-updates)
   - [lncli Updates](#lncli-updates)
   - [Code Health](#code-health)
   - [Breaking Changes](#breaking-changes)
   - [Performance Improvements](#performance-improvements)
-  - [Misc](#misc)
 - [Technical and Architectural Updates](#technical-and-architectural-updates)
   - [BOLT Spec Updates](#bolt-spec-updates)
   - [Testing](#testing)
@@ -108,6 +111,14 @@
 
 # New Features
 ## Functional Enhancements
+
+* Experimental support for [inbound routing
+  fees](https://github.com/lightningnetwork/lnd/pull/6703) is added. This allows
+  node operators to require senders to pay an inbound fee for forwards and
+  payments. It is recommended to only use negative fees (an inbound "discount")
+  initially to keep the channels open for senders that do not recognize inbound
+  fees. [Send support](https://github.com/lightningnetwork/lnd/pull/6934) is
+  implemented as well.
 
 * A new config value,
   [sweeper.maxfeerate](https://github.com/lightningnetwork/lnd/pull/7823), is
@@ -421,6 +432,7 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 * Elle Mouton
 * ErikEk
 * Jesse de Wit
+* Joost Jager
 * Keagan McClelland
 * Marcos Fernandez Perez
 * Matt Morehouse

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -109,6 +109,9 @@
 
 * [Removed](https://github.com/lightningnetwork/lnd/pull/8577) some unreachable code
 
+[Fixed](https://github.com/lightningnetwork/lnd/pull/8609) fixed a function
+call where arguments were swapped.
+
 # New Features
 ## Functional Enhancements
 
@@ -300,6 +303,10 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 * [Allow callers of `ListSweeps` to specify the start
   height](https://github.com/lightningnetwork/lnd/pull/7372).
 
+* [Coin Selection Strategy](https://github.com/lightningnetwork/lnd/pull/8515)
+  add coin selection strategy option to the following on-chain RPC calls
+  `EstimateFee`, `SendMany`, `SendCoins`, `BatchOpenChannel`, `SendOutputs`, and `FundPsbt`.
+
 ## lncli Updates
 
 * [Documented all available `lncli`
@@ -414,6 +421,9 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 * [Ensure that LND won't
   start](https://github.com/lightningnetwork/lnd/pull/8568) if native SQL is
   enabled but the channeldb already has any KV invoices stored.
+
+* [Fix a bug](https://github.com/lightningnetwork/lnd/pull/8595) when retrying
+  SQL InvoiceDB transactions due to database errors.
 
 ## Code Health
 

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -127,8 +127,13 @@
   node operators to require senders to pay an inbound fee for forwards and
   payments. It is recommended to only use negative fees (an inbound "discount")
   initially to keep the channels open for senders that do not recognize inbound
-  fees. [Send support](https://github.com/lightningnetwork/lnd/pull/6934) is
+  fees.
+
+  [Send support](https://github.com/lightningnetwork/lnd/pull/6934) is
   implemented as well.
+
+  [Positive inbound fees](https://github.com/lightningnetwork/lnd/pull/8627) 
+  can be enabled with the option `accept-positive-inbound-fees`.
 
 * A new config value,
   [sweeper.maxfeerate](https://github.com/lightningnetwork/lnd/pull/7823), is
@@ -197,6 +202,9 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   forwarding of blinded routes was added, along with [support](https://github.com/lightningnetwork/lnd/pull/8160)
   for forwarding blinded payments. Forwarding of blinded payments is disabled 
   by default, and the feature is not yet advertised to the network.
+
+* Introduced [fee bumper](https://github.com/lightningnetwork/lnd/pull/8424) to
+  handle bumping the fees of sweeping transactions properly.
 
 ## RPC Additions
 
@@ -321,6 +329,22 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   add coin selection strategy option to the following on-chain RPC calls
   `EstimateFee`, `SendMany`, `SendCoins`, `BatchOpenChannel`, `SendOutputs`, and `FundPsbt`.
 
+* Previously when callng `SendCoins`, `SendMany`, `OpenChannel` and
+  `CloseChannel` for coop close, it is allowed to specify both an empty
+  `SatPerVbyte` and `TargetConf`, and a default conf target of 6 will be used.
+  This is [no longer allowed](
+  https://github.com/lightningnetwork/lnd/pull/8422) and the caller must
+  specify either `SatPerVbyte` or `TargetConf` so the fee estimator can do a
+  proper fee estimation.
+
+* `BumpFee` has been updated to take advantage of the [new budget-based
+  sweeper](https://github.com/lightningnetwork/lnd/pull/8667). The param
+  `force` has been deprecated and replaced with a new param `immediate`, and a
+  new param `budget` is added to allow specifying max fees when sweeping
+  outputs. In addition, `PendingSweep` has added new fields `immediate`,
+  `budget`, and `deadline_height`, the fields `force`, `requested_conf_target`,
+  and `next_broadcast_height` are deprecated.
+
 ## lncli Updates
 
 * [Documented all available `lncli`
@@ -369,6 +393,10 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 
 * Bump sqlite version to [fix a data 
   race](https://github.com/lightningnetwork/lnd/pull/8567).
+
+* The pending inputs in the sweeper is now
+  [stateful](https://github.com/lightningnetwork/lnd/pull/8423) to better
+  manage the lifecycle of the inputs.
 
 ## Breaking Changes
 ## Performance Improvements
@@ -451,6 +479,10 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   retry](https://github.com/lightningnetwork/lnd/pull/8611) logic and isolation
   settings between `sqldb` and `kvdb` packages.
 
+* [Expanded SweeperStore](https://github.com/lightningnetwork/lnd/pull/8147) to
+  also store the feerate, fees paid, and whether it's published or not for a
+  given sweeping transaction.
+
 ## Code Health
 
 * [Remove database pointers](https://github.com/lightningnetwork/lnd/pull/8117) 
@@ -467,6 +499,7 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 * Carla Kirk-Cohen
 * Elle Mouton
 * ErikEk
+* Feelancer21
 * Jesse de Wit
 * Joost Jager
 * Keagan McClelland

--- a/docs/lnd/release-notes/release-notes-0.18.0.md
+++ b/docs/lnd/release-notes/release-notes-0.18.0.md
@@ -215,8 +215,11 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 
 * [Preparatory work](https://github.com/lightningnetwork/lnd/pull/8159) for 
   forwarding of blinded routes was added, along with [support](https://github.com/lightningnetwork/lnd/pull/8160)
-  for forwarding blinded payments. Forwarding of blinded payments is disabled 
-  by default, and the feature is not yet advertised to the network.
+  for forwarding blinded payments and [error handling](https://github.com/lightningnetwork/lnd/pull/8485).
+  With this change, LND is now eligible to be selected as part of a blinded 
+  route and can forward payments on behalf of nodes that have support for 
+  receiving to blinded paths. This upgrade provides a meaningful improvement 
+  to the anonymity set and usability of blinded paths in the Lightning Network.
 
 * Introduced [fee bumper](https://github.com/lightningnetwork/lnd/pull/8424) to
   handle bumping the fees of sweeping transactions properly. A
@@ -346,14 +349,6 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   add coin selection strategy option to the following on-chain RPC calls
   `EstimateFee`, `SendMany`, `SendCoins`, `BatchOpenChannel`, `SendOutputs`, and `FundPsbt`.
 
-* Previously when callng `SendCoins`, `SendMany`, `OpenChannel` and
-  `CloseChannel` for coop close, it is allowed to specify both an empty
-  `SatPerVbyte` and `TargetConf`, and a default conf target of 6 will be used.
-  This is [no longer allowed](
-  https://github.com/lightningnetwork/lnd/pull/8422) and the caller must
-  specify either `SatPerVbyte` or `TargetConf` so the fee estimator can do a
-  proper fee estimation.
-
 * `BumpFee` has been updated to take advantage of the [new budget-based
   sweeper](https://github.com/lightningnetwork/lnd/pull/8667). The param
   `force` has been deprecated and replaced with a new param `immediate`, and a
@@ -367,6 +362,10 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   ensures that the arguments are provided when calling `DeleteAllPayments` RPC,
   whether through gRPC or the REST API, due to the destructive nature of the
   operation.
+
+* When paying an AMP payment request, [the `--amp` flag is now
+  required](https://github.com/lightningnetwork/lnd/pull/8681) to be consistent
+  w/ the flow when a payment request isn't used. 
 
 ## lncli Updates
 
@@ -425,6 +424,18 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
   manage the lifecycle of the inputs.
 
 ## Breaking Changes
+
+* Previously when callng `SendCoins`, `SendMany`, `OpenChannel` and
+  `CloseChannel` for coop close, it is allowed to specify both an empty
+  `SatPerVbyte` and `TargetConf`, and a default conf target of 6 will be used.
+  This will [no longer be
+  allowed](https://github.com/lightningnetwork/lnd/pull/8422) in the next
+  release (v0.19.0) and the caller must specify either `SatPerVbyte` or
+  `TargetConf` so the fee estimator can do a proper fee estimation. For current
+  release, [an error will be
+  logged](https://github.com/lightningnetwork/lnd/pull/8693) when no values are
+  specified.
+
 ## Performance Improvements
 
 * Watchtower client DB migration to massively [improve the start-up 
@@ -532,6 +543,7 @@ bitcoin peers' feefilter values into account](https://github.com/lightningnetwor
 * Marcos Fernandez Perez
 * Matt Morehouse
 * Mohamed Awnallah
+* Olaoluwa Osuntokun
 * Ononiwu Maureen Chiamaka
 * Slyghtning
 * Tee8z

--- a/docs/lnd/release-notes/release-notes-0.18.1.md
+++ b/docs/lnd/release-notes/release-notes-0.18.1.md
@@ -19,6 +19,10 @@
 
 # Bug Fixes
 
+* `closedchannels` now [successfully reports](https://github.com/lightningnetwork/lnd/pull/8800)
+  settled balances even if the delivery address is set to an address that
+  LND does not control.
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions

--- a/docs/lnd/release-notes/release-notes-0.18.1.md
+++ b/docs/lnd/release-notes/release-notes-0.18.1.md
@@ -19,70 +19,25 @@
 
 # Bug Fixes
 
-* `closedchannels` now [successfully reports](https://github.com/lightningnetwork/lnd/pull/8800)
-  settled balances even if the delivery address is set to an address that
-  LND does not control.
-
-* [SendPaymentV2](https://github.com/lightningnetwork/lnd/pull/8734) now cancels
-  the background payment loop if the user cancels the stream context.
-
-* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8822) that caused
-  LND to read the config only partially and continued with the startup.
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8862) in error
+  matching from publishing transactions that can cause the broadcast process to
+  fail if `btcd` with an older version (pre-`v0.24.2`) is used.
 
 # New Features
 ## Functional Enhancements
 ## RPC Additions
-
-* The [SendPaymentRequest](https://github.com/lightningnetwork/lnd/pull/8734) 
-  message receives a new flag `cancelable` which indicates if the payment loop 
-  is cancelable. The cancellation can either occur manually by cancelling the 
-  send payment stream context, or automatically at the end of the timeout period 
-  if the user provided `timeout_seconds`.
-
 ## lncli Additions
-
-* [Added](https://github.com/lightningnetwork/lnd/pull/8491) the `cltv_expiry`
-  argument to `addinvoice` and `addholdinvoice`, allowing users to set the
-  `min_final_cltv_expiry_delta`.
-
-* The [`lncli wallet estimatefeerate`](https://github.com/lightningnetwork/lnd/pull/8730)
-  command returns the fee rate estimate for on-chain transactions in sat/kw and
-  sat/vb to achieve a given confirmation target.
 
 # Improvements
 ## Functional Updates
 ## RPC Updates
-
-* [`xImportMissionControl`](https://github.com/lightningnetwork/lnd/pull/8779) 
-  now accepts `0` failure amounts.
-
-* [`ChanInfoRequest`](https://github.com/lightningnetwork/lnd/pull/8813)
-  adds support for channel points.
-
 ## lncli Updates
-
-* [`importmc`](https://github.com/lightningnetwork/lnd/pull/8779) now accepts
-  `0` failure amounts.
- 
-* [`getchaninfo`](https://github.com/lightningnetwork/lnd/pull/8813) now accepts
-  a channel outpoint besides a channel id.
-
-* [Fixed](https://github.com/lightningnetwork/lnd/pull/8823) how we parse the
-  `--amp` flag when sending a payment specifying the payment request.
-
 ## Code Health
 ## Breaking Changes
 ## Performance Improvements
 
-* Mission Control Store [improved performance during DB
-  flushing](https://github.com/lightningnetwork/lnd/pull/8549) stage.
-
 # Technical and Architectural Updates
 ## BOLT Spec Updates
-
-* Start assuming that all hops used during path-finding and route construction
-  [support the TLV onion 
-  format](https://github.com/lightningnetwork/lnd/pull/8791).
 
 ## Testing
 ## Database
@@ -91,8 +46,4 @@
 
 # Contributors (Alphabetical Order)
 
-* Andras Banki-Horvath
-* Bufo
-* Elle Mouton
-* Matheus Degiovani
-* Slyghtning
+* Yyforyongyu

--- a/docs/lnd/release-notes/release-notes-0.18.1.md
+++ b/docs/lnd/release-notes/release-notes-0.18.1.md
@@ -46,6 +46,9 @@
 * [`getchaninfo`](https://github.com/lightningnetwork/lnd/pull/8813) now accepts
   a channel outpoint besides a channel id.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8823) how we parse the
+  `--amp` flag when sending a payment specifying the payment request.
+
 ## Code Health
 ## Breaking Changes
 ## Performance Improvements
@@ -59,4 +62,5 @@
 
 # Contributors (Alphabetical Order)
 
+* Andras Banki-Horvath
 * Bufo

--- a/docs/lnd/release-notes/release-notes-0.18.1.md
+++ b/docs/lnd/release-notes/release-notes-0.18.1.md
@@ -32,6 +32,10 @@
   argument to `addinvoice` and `addholdinvoice`, allowing users to set the
   `min_final_cltv_expiry_delta`
 
+* The [`lncli wallet estimatefeerate`](https://github.com/lightningnetwork/lnd/pull/8730)
+  command returns the fee rate estimate for on-chain transactions in sat/kw and
+  sat/vb to achieve a given confirmation target.
+
 # Improvements
 ## Functional Updates
 ## RPC Updates

--- a/docs/lnd/release-notes/release-notes-0.18.1.md
+++ b/docs/lnd/release-notes/release-notes-0.18.1.md
@@ -35,10 +35,16 @@
 * [`xImportMissionControl`](https://github.com/lightningnetwork/lnd/pull/8779) 
   now accepts `0` failure amounts.
 
+* [`ChanInfoRequest`](https://github.com/lightningnetwork/lnd/pull/8813)
+  adds support for channel points.
+
 ## lncli Updates
 
 * [`importmc`](https://github.com/lightningnetwork/lnd/pull/8779) now accepts
   `0` failure amounts.
+ 
+* [`getchaninfo`](https://github.com/lightningnetwork/lnd/pull/8813) now accepts
+  a channel outpoint besides a channel id.
 
 ## Code Health
 ## Breaking Changes

--- a/docs/lnd/release-notes/release-notes-0.18.1.md
+++ b/docs/lnd/release-notes/release-notes-0.18.1.md
@@ -1,0 +1,42 @@
+# Release Notes
+- [Bug Fixes](#bug-fixes)
+- [New Features](#new-features)
+    - [Functional Enhancements](#functional-enhancements)
+    - [RPC Additions](#rpc-additions)
+    - [lncli Additions](#lncli-additions)
+- [Improvements](#improvements)
+    - [Functional Updates](#functional-updates)
+    - [RPC Updates](#rpc-updates)
+    - [lncli Updates](#lncli-updates)
+    - [Breaking Changes](#breaking-changes)
+    - [Performance Improvements](#performance-improvements)
+- [Technical and Architectural Updates](#technical-and-architectural-updates)
+    - [BOLT Spec Updates](#bolt-spec-updates)
+    - [Testing](#testing)
+    - [Database](#database)
+    - [Code Health](#code-health)
+    - [Tooling and Documentation](#tooling-and-documentation)
+
+# Bug Fixes
+
+# New Features
+## Functional Enhancements
+## RPC Additions
+## lncli Additions
+
+# Improvements
+## Functional Updates
+## RPC Updates
+## lncli Updates
+## Code Health
+## Breaking Changes
+## Performance Improvements
+
+# Technical and Architectural Updates
+## BOLT Spec Updates
+## Testing
+## Database
+## Code Health
+## Tooling and Documentation
+
+# Contributors (Alphabetical Order)

--- a/docs/lnd/release-notes/release-notes-0.18.1.md
+++ b/docs/lnd/release-notes/release-notes-0.18.1.md
@@ -22,15 +22,25 @@
 * `closedchannels` now [successfully reports](https://github.com/lightningnetwork/lnd/pull/8800)
   settled balances even if the delivery address is set to an address that
   LND does not control.
+ 
+* [SendPaymentV2](https://github.com/lightningnetwork/lnd/pull/8734) now cancels
+  the background payment loop if the user cancels the stream context.
 
 # New Features
 ## Functional Enhancements
 ## RPC Additions
+
+* The [SendPaymentRequest](https://github.com/lightningnetwork/lnd/pull/8734) 
+  message receives a new flag `cancelable` which indicates if the payment loop 
+  is cancelable. The cancellation can either occur manually by cancelling the 
+  send payment stream context, or automatically at the end of the timeout period 
+  if the user provided `timeout_seconds`.
+
 ## lncli Additions
 
 * [Added](https://github.com/lightningnetwork/lnd/pull/8491) the `cltv_expiry`
   argument to `addinvoice` and `addholdinvoice`, allowing users to set the
-  `min_final_cltv_expiry_delta`
+  `min_final_cltv_expiry_delta`.
 
 * The [`lncli wallet estimatefeerate`](https://github.com/lightningnetwork/lnd/pull/8730)
   command returns the fee rate estimate for on-chain transactions in sat/kw and
@@ -72,3 +82,4 @@
 
 * Andras Banki-Horvath
 * Bufo
+* Slyghtning

--- a/docs/lnd/release-notes/release-notes-0.18.1.md
+++ b/docs/lnd/release-notes/release-notes-0.18.1.md
@@ -24,6 +24,10 @@
 ## RPC Additions
 ## lncli Additions
 
+* [Added](https://github.com/lightningnetwork/lnd/pull/8491) the `cltv_expiry`
+  argument to `addinvoice` and `addholdinvoice`, allowing users to set the
+  `min_final_cltv_expiry_delta`
+
 # Improvements
 ## Functional Updates
 ## RPC Updates

--- a/docs/lnd/release-notes/release-notes-0.18.1.md
+++ b/docs/lnd/release-notes/release-notes-0.18.1.md
@@ -27,7 +27,15 @@
 # Improvements
 ## Functional Updates
 ## RPC Updates
+
+* [`xImportMissionControl`](https://github.com/lightningnetwork/lnd/pull/8779) 
+  now accepts `0` failure amounts.
+
 ## lncli Updates
+
+* [`importmc`](https://github.com/lightningnetwork/lnd/pull/8779) now accepts
+  `0` failure amounts.
+
 ## Code Health
 ## Breaking Changes
 ## Performance Improvements
@@ -40,3 +48,5 @@
 ## Tooling and Documentation
 
 # Contributors (Alphabetical Order)
+
+* Bufo

--- a/docs/lnd/release-notes/release-notes-0.18.1.md
+++ b/docs/lnd/release-notes/release-notes-0.18.1.md
@@ -79,6 +79,11 @@
 
 # Technical and Architectural Updates
 ## BOLT Spec Updates
+
+* Start assuming that all hops used during path-finding and route construction
+  [support the TLV onion 
+  format](https://github.com/lightningnetwork/lnd/pull/8791).
+
 ## Testing
 ## Database
 ## Code Health
@@ -88,5 +93,6 @@
 
 * Andras Banki-Horvath
 * Bufo
+* Elle Mouton
 * Matheus Degiovani
 * Slyghtning

--- a/docs/lnd/release-notes/release-notes-0.18.1.md
+++ b/docs/lnd/release-notes/release-notes-0.18.1.md
@@ -22,9 +22,12 @@
 * `closedchannels` now [successfully reports](https://github.com/lightningnetwork/lnd/pull/8800)
   settled balances even if the delivery address is set to an address that
   LND does not control.
- 
+
 * [SendPaymentV2](https://github.com/lightningnetwork/lnd/pull/8734) now cancels
   the background payment loop if the user cancels the stream context.
+
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8822) that caused
+  LND to read the config only partially and continued with the startup.
 
 # New Features
 ## Functional Enhancements
@@ -71,6 +74,9 @@
 ## Breaking Changes
 ## Performance Improvements
 
+* Mission Control Store [improved performance during DB
+  flushing](https://github.com/lightningnetwork/lnd/pull/8549) stage.
+
 # Technical and Architectural Updates
 ## BOLT Spec Updates
 ## Testing
@@ -82,4 +88,5 @@
 
 * Andras Banki-Horvath
 * Bufo
+* Matheus Degiovani
 * Slyghtning

--- a/docs/lnd/release-notes/release-notes-0.18.2.md
+++ b/docs/lnd/release-notes/release-notes-0.18.2.md
@@ -91,6 +91,10 @@
 
 ## Testing
 ## Database
+
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8854) pagination issues 
+  in SQL invoicedb queries.
+
 ## Code Health
 ## Tooling and Documentation
 

--- a/docs/lnd/release-notes/release-notes-0.18.2.md
+++ b/docs/lnd/release-notes/release-notes-0.18.2.md
@@ -19,76 +19,25 @@
 
 # Bug Fixes
 
-* `closedchannels` now [successfully reports](https://github.com/lightningnetwork/lnd/pull/8800)
-  settled balances even if the delivery address is set to an address that
-  LND does not control.
-
-* [SendPaymentV2](https://github.com/lightningnetwork/lnd/pull/8734) now cancels
-  the background payment loop if the user cancels the stream context.
-
-* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8822) that caused
-  LND to read the config only partially and continued with the startup.
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8887) in error
+  matching from publishing already confirmed transactions that can cause lnd
+  fail to startup if `btcd` with an older version (pre-`v0.24.2`) is used.
 
 # New Features
 ## Functional Enhancements
 ## RPC Additions
-
-* The [SendPaymentRequest](https://github.com/lightningnetwork/lnd/pull/8734) 
-  message receives a new flag `cancelable` which indicates if the payment loop 
-  is cancelable. The cancellation can either occur manually by cancelling the 
-  send payment stream context, or automatically at the end of the timeout period 
-  if the user provided `timeout_seconds`.
-
 ## lncli Additions
-
-* [Added](https://github.com/lightningnetwork/lnd/pull/8491) the `cltv_expiry`
-  argument to `addinvoice` and `addholdinvoice`, allowing users to set the
-  `min_final_cltv_expiry_delta`.
-
-* The [`lncli wallet estimatefeerate`](https://github.com/lightningnetwork/lnd/pull/8730)
-  command returns the fee rate estimate for on-chain transactions in sat/kw and
-  sat/vb to achieve a given confirmation target.
 
 # Improvements
 ## Functional Updates
 ## RPC Updates
-
-* [`xImportMissionControl`](https://github.com/lightningnetwork/lnd/pull/8779) 
-  now accepts `0` failure amounts.
-
-* [`ChanInfoRequest`](https://github.com/lightningnetwork/lnd/pull/8813)
-  adds support for channel points.
-
 ## lncli Updates
-
-* [`importmc`](https://github.com/lightningnetwork/lnd/pull/8779) now accepts
-  `0` failure amounts.
- 
-* [`getchaninfo`](https://github.com/lightningnetwork/lnd/pull/8813) now accepts
-  a channel outpoint besides a channel id.
-
-* [Fixed](https://github.com/lightningnetwork/lnd/pull/8823) how we parse the
-  `--amp` flag when sending a payment specifying the payment request.
-
 ## Code Health
 ## Breaking Changes
 ## Performance Improvements
 
-* Mission Control Store [improved performance during DB
-  flushing](https://github.com/lightningnetwork/lnd/pull/8549) stage.
-
 # Technical and Architectural Updates
 ## BOLT Spec Updates
-
-* Start assuming that all hops used during path-finding and route construction
-  [support the TLV onion 
-  format](https://github.com/lightningnetwork/lnd/pull/8791).
-
-* Allow channel fundee to send a [minimum confirmation depth of
-  0](https://github.com/lightningnetwork/lnd/pull/8796) for a non-zero-conf
-  channel. We will still wait for the channel to have at least one confirmation
-  and so the main change here is that we don't error out for such a case.
-
 ## Testing
 ## Database
 
@@ -100,9 +49,4 @@
 
 # Contributors (Alphabetical Order)
 
-* Andras Banki-Horvath
-* Bufo
-* Elle Mouton
-* Matheus Degiovani
-* Oliver Gugger
-* Slyghtning
+* Yong Yu

--- a/docs/lnd/release-notes/release-notes-0.18.2.md
+++ b/docs/lnd/release-notes/release-notes-0.18.2.md
@@ -1,0 +1,98 @@
+# Release Notes
+- [Bug Fixes](#bug-fixes)
+- [New Features](#new-features)
+    - [Functional Enhancements](#functional-enhancements)
+    - [RPC Additions](#rpc-additions)
+    - [lncli Additions](#lncli-additions)
+- [Improvements](#improvements)
+    - [Functional Updates](#functional-updates)
+    - [RPC Updates](#rpc-updates)
+    - [lncli Updates](#lncli-updates)
+    - [Breaking Changes](#breaking-changes)
+    - [Performance Improvements](#performance-improvements)
+- [Technical and Architectural Updates](#technical-and-architectural-updates)
+    - [BOLT Spec Updates](#bolt-spec-updates)
+    - [Testing](#testing)
+    - [Database](#database)
+    - [Code Health](#code-health)
+    - [Tooling and Documentation](#tooling-and-documentation)
+
+# Bug Fixes
+
+* `closedchannels` now [successfully reports](https://github.com/lightningnetwork/lnd/pull/8800)
+  settled balances even if the delivery address is set to an address that
+  LND does not control.
+
+* [SendPaymentV2](https://github.com/lightningnetwork/lnd/pull/8734) now cancels
+  the background payment loop if the user cancels the stream context.
+
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8822) that caused
+  LND to read the config only partially and continued with the startup.
+
+# New Features
+## Functional Enhancements
+## RPC Additions
+
+* The [SendPaymentRequest](https://github.com/lightningnetwork/lnd/pull/8734) 
+  message receives a new flag `cancelable` which indicates if the payment loop 
+  is cancelable. The cancellation can either occur manually by cancelling the 
+  send payment stream context, or automatically at the end of the timeout period 
+  if the user provided `timeout_seconds`.
+
+## lncli Additions
+
+* [Added](https://github.com/lightningnetwork/lnd/pull/8491) the `cltv_expiry`
+  argument to `addinvoice` and `addholdinvoice`, allowing users to set the
+  `min_final_cltv_expiry_delta`.
+
+* The [`lncli wallet estimatefeerate`](https://github.com/lightningnetwork/lnd/pull/8730)
+  command returns the fee rate estimate for on-chain transactions in sat/kw and
+  sat/vb to achieve a given confirmation target.
+
+# Improvements
+## Functional Updates
+## RPC Updates
+
+* [`xImportMissionControl`](https://github.com/lightningnetwork/lnd/pull/8779) 
+  now accepts `0` failure amounts.
+
+* [`ChanInfoRequest`](https://github.com/lightningnetwork/lnd/pull/8813)
+  adds support for channel points.
+
+## lncli Updates
+
+* [`importmc`](https://github.com/lightningnetwork/lnd/pull/8779) now accepts
+  `0` failure amounts.
+ 
+* [`getchaninfo`](https://github.com/lightningnetwork/lnd/pull/8813) now accepts
+  a channel outpoint besides a channel id.
+
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8823) how we parse the
+  `--amp` flag when sending a payment specifying the payment request.
+
+## Code Health
+## Breaking Changes
+## Performance Improvements
+
+* Mission Control Store [improved performance during DB
+  flushing](https://github.com/lightningnetwork/lnd/pull/8549) stage.
+
+# Technical and Architectural Updates
+## BOLT Spec Updates
+
+* Start assuming that all hops used during path-finding and route construction
+  [support the TLV onion 
+  format](https://github.com/lightningnetwork/lnd/pull/8791).
+
+## Testing
+## Database
+## Code Health
+## Tooling and Documentation
+
+# Contributors (Alphabetical Order)
+
+* Andras Banki-Horvath
+* Bufo
+* Elle Mouton
+* Matheus Degiovani
+* Slyghtning

--- a/docs/lnd/release-notes/release-notes-0.18.2.md
+++ b/docs/lnd/release-notes/release-notes-0.18.2.md
@@ -84,6 +84,11 @@
   [support the TLV onion 
   format](https://github.com/lightningnetwork/lnd/pull/8791).
 
+* Allow channel fundee to send a [minimum confirmation depth of
+  0](https://github.com/lightningnetwork/lnd/pull/8796) for a non-zero-conf
+  channel. We will still wait for the channel to have at least one confirmation
+  and so the main change here is that we don't error out for such a case.
+
 ## Testing
 ## Database
 ## Code Health

--- a/docs/lnd/release-notes/release-notes-0.18.2.md
+++ b/docs/lnd/release-notes/release-notes-0.18.2.md
@@ -40,10 +40,6 @@
 ## BOLT Spec Updates
 ## Testing
 ## Database
-
-* [Fixed](https://github.com/lightningnetwork/lnd/pull/8854) pagination issues 
-  in SQL invoicedb queries.
-
 ## Code Health
 ## Tooling and Documentation
 

--- a/docs/lnd/release-notes/release-notes-0.18.2.md
+++ b/docs/lnd/release-notes/release-notes-0.18.2.md
@@ -95,4 +95,5 @@
 * Bufo
 * Elle Mouton
 * Matheus Degiovani
+* Oliver Gugger
 * Slyghtning

--- a/docs/lnd/release-notes/release-notes-0.18.3.md
+++ b/docs/lnd/release-notes/release-notes-0.18.3.md
@@ -100,7 +100,16 @@
   invoice database. Invoices with incorrect expiry values will be updated to
   24-hour expiry, which is the default behavior in LND.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8854) pagination issues
+  in SQL invoicedb queries.
+
 ## Code Health
+
+* [Move graph building and
+  maintaining](https://github.com/lightningnetwork/lnd/pull/8848) duties from
+  the `routing.ChannelRouter` to the new `graph.Builder` sub-system and also
+  remove the `channeldb.ChannelGraph` pointer from the `ChannelRouter`.
+
 ## Tooling and Documentation
 
 # Contributors (Alphabetical Order)

--- a/docs/lnd/release-notes/release-notes-0.18.3.md
+++ b/docs/lnd/release-notes/release-notes-0.18.3.md
@@ -1,0 +1,105 @@
+# Release Notes
+- [Bug Fixes](#bug-fixes)
+- [New Features](#new-features)
+    - [Functional Enhancements](#functional-enhancements)
+    - [RPC Additions](#rpc-additions)
+    - [lncli Additions](#lncli-additions)
+- [Improvements](#improvements)
+    - [Functional Updates](#functional-updates)
+    - [RPC Updates](#rpc-updates)
+    - [lncli Updates](#lncli-updates)
+    - [Breaking Changes](#breaking-changes)
+    - [Performance Improvements](#performance-improvements)
+- [Technical and Architectural Updates](#technical-and-architectural-updates)
+    - [BOLT Spec Updates](#bolt-spec-updates)
+    - [Testing](#testing)
+    - [Database](#database)
+    - [Code Health](#code-health)
+    - [Tooling and Documentation](#tooling-and-documentation)
+
+# Bug Fixes
+
+* `closedchannels` now [successfully reports](https://github.com/lightningnetwork/lnd/pull/8800)
+  settled balances even if the delivery address is set to an address that
+  LND does not control.
+
+* [SendPaymentV2](https://github.com/lightningnetwork/lnd/pull/8734) now cancels
+  the background payment loop if the user cancels the stream context.
+
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/8822) that caused
+  LND to read the config only partially and continued with the startup.
+
+# New Features
+## Functional Enhancements
+## RPC Additions
+
+* The [SendPaymentRequest](https://github.com/lightningnetwork/lnd/pull/8734) 
+  message receives a new flag `cancelable` which indicates if the payment loop 
+  is cancelable. The cancellation can either occur manually by cancelling the 
+  send payment stream context, or automatically at the end of the timeout period 
+  if the user provided `timeout_seconds`.
+
+## lncli Additions
+
+* [Added](https://github.com/lightningnetwork/lnd/pull/8491) the `cltv_expiry`
+  argument to `addinvoice` and `addholdinvoice`, allowing users to set the
+  `min_final_cltv_expiry_delta`.
+
+* The [`lncli wallet estimatefeerate`](https://github.com/lightningnetwork/lnd/pull/8730)
+  command returns the fee rate estimate for on-chain transactions in sat/kw and
+  sat/vb to achieve a given confirmation target.
+
+# Improvements
+## Functional Updates
+## RPC Updates
+
+* [`xImportMissionControl`](https://github.com/lightningnetwork/lnd/pull/8779) 
+  now accepts `0` failure amounts.
+
+* [`ChanInfoRequest`](https://github.com/lightningnetwork/lnd/pull/8813)
+  adds support for channel points.
+
+## lncli Updates
+
+* [`importmc`](https://github.com/lightningnetwork/lnd/pull/8779) now accepts
+  `0` failure amounts.
+ 
+* [`getchaninfo`](https://github.com/lightningnetwork/lnd/pull/8813) now accepts
+  a channel outpoint besides a channel id.
+
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/8823) how we parse the
+  `--amp` flag when sending a payment specifying the payment request.
+
+## Code Health
+## Breaking Changes
+## Performance Improvements
+
+* Mission Control Store [improved performance during DB
+  flushing](https://github.com/lightningnetwork/lnd/pull/8549) stage.
+
+# Technical and Architectural Updates
+## BOLT Spec Updates
+
+* Start assuming that all hops used during path-finding and route construction
+  [support the TLV onion 
+  format](https://github.com/lightningnetwork/lnd/pull/8791).
+
+* Allow channel fundee to send a [minimum confirmation depth of
+  0](https://github.com/lightningnetwork/lnd/pull/8796) for a non-zero-conf
+  channel. We will still wait for the channel to have at least one confirmation
+  and so the main change here is that we don't error out for such a case.
+
+## Testing
+## Database
+## Code Health
+## Tooling and Documentation
+
+# Contributors (Alphabetical Order)
+
+* Andras Banki-Horvath
+* Bufo
+* Elle Mouton
+* Matheus Degiovani
+* Oliver Gugger
+* Slyghtning
+* Yong Yu

--- a/docs/lnd/release-notes/release-notes-0.18.3.md
+++ b/docs/lnd/release-notes/release-notes-0.18.3.md
@@ -91,6 +91,12 @@
 
 ## Testing
 ## Database
+
+* [Migrate](https://github.com/lightningnetwork/lnd/pull/8855) incorrectly
+  stored invoice expiry values. This migration only affects users of native SQL
+  invoice database. Invoices with incorrect expiry values will be updated to
+  24-hour expiry, which is the default behavior in LND.
+
 ## Code Health
 ## Tooling and Documentation
 

--- a/docs/lnd/release-notes/release-notes-0.18.3.md
+++ b/docs/lnd/release-notes/release-notes-0.18.3.md
@@ -89,6 +89,9 @@
   channel. We will still wait for the channel to have at least one confirmation
   and so the main change here is that we don't error out for such a case.
 
+* [Groundwork](https://github.com/lightningnetwork/lnd/pull/8752) in preparation
+  for implementing route blinding receives.
+
 ## Testing
 ## Database
 


### PR DESCRIPTION
This github action
https://github.com/marketplace/actions/404-links
should automatically test HTTP resources to ensure they don't return a 404 error code.

Pull Request Checklist
- [x] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
