### PR TITLE
lint: Add GH action to find HTTP resources returning a 404 error code

### DIFF
--- a/.404-links.yml
+++ b/.404-links.yml
@@ -1,0 +1,8 @@
+# folder: docs/ # The folder that required to be parsed
+httpsOnly: true # If you want enforce only HTTPS links
+pullRequestReview: true # If you want a nice review in your pull requests
+ignore: 
+  urls: # Array of url to ignore, wildcarded
+  files: # Array of markdown file the action shouldn't parse.  Addressed by relative path from the folder shared above
+delay:
+  # 'https://gitlab.com': 500 # Perform a pause of 500ms at each call matching the url

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,17 @@
+name: Markdown lint
+# https://github.com/marketplace/actions/404-links
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: 'restqa-404-links'
+      uses: restqa/404-links@3.1.4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pull Request Checklist
- [ ] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
