### PR TITLE
Update dead link

### DIFF
--- a/build-a-lapp/local-cluster-setup-with-polar/README.md
+++ b/build-a-lapp/local-cluster-setup-with-polar/README.md
@@ -2,7 +2,7 @@
 
 ## Install Polar
 
-This tutorial will leverage the Polar application for setting up a local cluster of Lightning Network nodes on regtest. Polar [can be downloaded](https://github.com/lightninglabs/docs.lightning.engineering/tree/9423e81a91e5a382442d5fa2fdacde019133dbcb/build-a-lapp/lightningpolar.com) for MacOS, Linux, and Windows. The source code is hosted [on Github](https://github.com/jamaljsr/polar/releases/).
+This tutorial will leverage the Polar application for setting up a local cluster of Lightning Network nodes on regtest. Polar [can be downloaded](https://lightningpolar.com/) for MacOS, Linux, and Windows. The source code is hosted [on Github](https://github.com/jamaljsr/polar/releases/).
 
 ![Polar website](../../.gitbook/assets/polarWebsite.png)
 


### PR DESCRIPTION
Removes a dead link and replaces it with a direct link to the Lightning Polar site

Pull Request Checklist
- [ ] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
