### PR TITLE
add clarity on how RFQ messaging actually happens

### DIFF
--- a/lightning-network-tools/taproot-assets/rfq.md
+++ b/lightning-network-tools/taproot-assets/rfq.md
@@ -8,6 +8,8 @@ description: >-
 
 When sending Taproot Assets over the Lightning Network, an Edge Node is needed. This Edge Node receives the Taproot Asset in the channel with the direct user and swaps it for bitcoin. As the swap rate between Taproot Assets and bitcoin likely fluctuates, the user may make a Request for Quote to the Edge Node before generating a Lightning Network invoice or initiating a payment.
 
+This request is made using BOLT 01 messages over an existing encrypted and authenticated BOLT 08 connection. The connection already exists because it is used for establishing and coordinating the Taproot Asset Channel in a way very similiar to normal Lightning channels. For more information about connection and messaging, see the [Last Mile Routing](https://github.com/Roasbeef/blips/blob/tap-blip/blip-tap.md#last-mile-routing) section of [Taproot Asset Channels bLIP](https://github.com/Roasbeef/blips/blob/tap-blip/blip-tap.md).
+
 [Learn more: Edge Nodes](../../the-lightning-network/taproot-assets/edge-nodes.md)
 
 The Request for Quote contains a rate and an expiration time, which allows the sender to decide whether they want to complete the payment and craft a route to the intended recipient.

--- a/lightning-network-tools/taproot-assets/rfq.md
+++ b/lightning-network-tools/taproot-assets/rfq.md
@@ -8,7 +8,7 @@ description: >-
 
 When sending Taproot Assets over the Lightning Network, an Edge Node is needed. This Edge Node receives the Taproot Asset in the channel with the direct user and swaps it for bitcoin. As the swap rate between Taproot Assets and bitcoin likely fluctuates, the user may make a Request for Quote to the Edge Node before generating a Lightning Network invoice or initiating a payment.
 
-This request is made using BOLT 01 messages over an existing encrypted and authenticated BOLT 08 connection. The connection already exists because it is used for establishing and coordinating the Taproot Asset Channel in a way very similiar to normal Lightning channels. For more information about connection and messaging, see the [Last Mile Routing](https://github.com/Roasbeef/blips/blob/tap-blip/blip-tap.md#last-mile-routing) section of [Taproot Asset Channels bLIP](https://github.com/Roasbeef/blips/blob/tap-blip/blip-tap.md).
+This request is made using [BOLT 01](https://github.com/lightning/bolts/blob/master/01-messaging.md) messages over an existing encrypted and authenticated [BOLT 08](https://github.com/lightning/bolts/blob/master/08-transport.md) connection. The connection already exists because it is used for establishing and coordinating the Taproot Asset Channel in a way very similiar to normal Lightning channels. For more information about connection and messaging, see the [Last Mile Routing](https://github.com/Roasbeef/blips/blob/tap-blip/blip-tap.md#last-mile-routing) section of [Taproot Asset Channels bLIP](https://github.com/Roasbeef/blips/blob/tap-blip/blip-tap.md).
 
 [Learn more: Edge Nodes](../../the-lightning-network/taproot-assets/edge-nodes.md)
 


### PR DESCRIPTION
This PR adds some brief clarity on how RFQ messages are actually exchanged.


Pull Request Checklist
- [X] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
