### PR TITLE
GitHub: sync taproot-assets docs

### DIFF
--- a/.github/workflows/doc-sync.yaml
+++ b/.github/workflows/doc-sync.yaml
@@ -42,6 +42,10 @@ jobs:
             org: lightninglabs
             src: docs
             dest: docs/pool
+          - repo: taproot-assets
+            org: lightninglabs
+            src: docs
+            dest: docs/taproot-assets
 
     steps:
       - name: Checkout docs.lightning.engineering repo


### PR DESCRIPTION
Also sync the `docs/` folder from the [Taproot Assets repository](https://github.com/lightninglabs/taproot-assets/tree/main/docs).