### PR TITLE
Typo Update accounting.md

### DIFF
--- a/docs/faraday/accounting.md
+++ b/docs/faraday/accounting.md
@@ -4,7 +4,7 @@ These reports are formatted using the [Harmony Reporting Standard](https://githu
 This document provides a description of the entries in these reports. 
 
 ## Bitcoin Backend
-It is strongly recommended that Faraday is run with a connection to a Bitcon node when these reports are generated. This is required to lookup fee entries for channel close transactions and sweep fees. If a connection to a bitcoin node is not provided, warnings will be logged for the transactions that do not have fee entries. 
+It is strongly recommended that Faraday is run with a connection to a Bitcoin node when these reports are generated. This is required to lookup fee entries for channel close transactions and sweep fees. If a connection to a bitcoin node is not provided, warnings will be logged for the transactions that do not have fee entries. 
 
 ## Common Fields
 For brevity, the following fields which have the same meaning for each entry will be omitted: 


### PR DESCRIPTION
**Description:**

This pull request addresses a minor but important typo in the documentation. The word "Bitcon" has been corrected to "Bitcoin" in the **Bitcoin Backend** section. 

**Fix:**

- Corrected the typo "Bitcon" to "Bitcoin" in the sentence:
  
  > "It is strongly recommended that Faraday is run with a connection to a **Bitcon** node..."

**Importance:**

This is a minor correction, but it's important for accuracy and clarity. "Bitcoin" is the proper name of the blockchain, and leaving the typo "Bitcon" could cause confusion for readers, especially for those unfamiliar with the system. Ensuring proper spelling is crucial for maintaining the professionalism and credibility of the documentation.


Pull Request Checklist
- [x] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
