### PR TITLE
chore: fix typo in ruby.md

### DIFF
--- a/docs/lnd/grpc/ruby.md
+++ b/docs/lnd/grpc/ruby.md
@@ -62,7 +62,7 @@ $:.unshift(File.dirname(__FILE__))
 require 'grpc'
 require 'lightning_services_pb'
 
-# Due to updated ECDSA generated tls.cert we need to let gprc know that
+# Due to updated ECDSA generated tls.cert we need to let grpc know that
 # we need to use that cipher suite otherwise there will be a handshake
 # error when we communicate with the lnd rpc server.
 ENV['GRPC_SSL_CIPHER_SUITES'] = "HIGH+ECDSA"


### PR DESCRIPTION
The typo `gprc` instead of `grpc` is important because `gRPC` is a widely used framework for remote procedure calls (RPC). Any error in its name can cause the code to fail to work properly.

If the wrong name is used, such as `gprc`, the compiler or interpreter won't recognize it as the correct library, and any functionality relying on gRPC won't work. This will result in compilation or runtime errors, breaking the program.
