### PR TITLE
docs: merge UTXO/script level rows in timelocks table

### DIFF
--- a/the-lightning-network/multihop-payments/timelocks.md
+++ b/the-lightning-network/multihop-payments/timelocks.md
@@ -8,11 +8,10 @@ description: >-
 
 A time-locked Bitcoin transaction is one that is only valid after a certain period of time. Such timelocks are used extensively in the Lightning Network and broadly fall under two categories, absolute timelocks and relative timelocks.
 
-| <p><br></p>       | Absolute Timelock   | Relative Timelock   |
-| ----------------- | ------------------- | ------------------- |
-| Transaction Level | nLockTime           | nSequence           |
-| UTXO Level        | CheckLockTimeVerify | CheckSequenceVerify |
-| (or Script Level) | CLTV                | CSV                 |
+| <p><br></p>                   | Absolute Timelock          | Relative Timelock          |
+| ----------------------------- | -------------------------- | -------------------------- |
+| Transaction Level             | nLockTime                  | nSequence                  |
+| UTXO (or Script) Level        | CheckLockTimeVerify (CLTV) | CheckSequenceVerify (CSV)  |
 
 ## Absolute timelocks <a href="#docs-internal-guid-0d5e29e5-7fff-99b6-bc86-be913c8afa87" id="docs-internal-guid-0d5e29e5-7fff-99b6-bc86-be913c8afa87"></a>
 


### PR DESCRIPTION
Gemini made the category mistake and referenced this as a source, so I followed the track; not a big issue, but it could be clearer.

Pull Request Checklist
- [x] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
